### PR TITLE
Send the caller name in all SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ use zero_sdk::{Arguments, Zero};
 let secrets = Zero::new(Arguments {
     pick: Some(vec![String::from("my-secret")]),
     token: String::from("my-zero-token-from-env"),
+    caller_name: Some(String::from("cicd")),
 })
 .unwrap()
 .fetch();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl Zero {
             "query":
                 format!(
                     "query {{
-                        secrets(zeroToken: \"{}\", pick: [{}], \"{}\") {{
+                        secrets(zeroToken: \"{}\", pick: [{}], callerName: \"{}\") {{
                             name
                             fields {{
                                 name value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod tests;
 /// Zero API client. Instantiate with a token, than call the `.fetch()` method to download secrets.
 pub struct Zero {
     api_url: String,
+    caller_name: Option<String>,
     pick: Vec<String>,
     token: String,
 }
@@ -13,6 +14,7 @@ pub struct Zero {
 pub struct Arguments {
     pub token: String,
     pub pick: Option<Vec<String>>,
+    pub caller_name: Option<String>,
 }
 
 /// The main client for accessing Zero GraphQL API.
@@ -24,11 +26,12 @@ pub struct Arguments {
 /// let client = Zero::new(Arguments {
 ///     pick: Some(vec![String::from("my-secret")]),
 ///     token: String::from("my-zero-token"),
+///     caller_name: None,
 /// })
 /// .unwrap();
 /// ```
 impl Zero {
-    /// Set the URL which will be called in fetch(). The method was added mostly for convience of testing.
+    /// Set the URL which will be called in fetch(). The method was added mostly for convenience of testing.
     pub fn set_api_url(mut self, new_api_url: String) -> Self {
         self.api_url = new_api_url;
         return self;
@@ -42,7 +45,7 @@ impl Zero {
             "query":
                 format!(
                     "query {{
-                        secrets(zeroToken: \"{}\", pick: [{}]) {{
+                        secrets(zeroToken: \"{}\", pick: [{}], \"{}\") {{
                             name
                             fields {{
                                 name value
@@ -56,6 +59,7 @@ impl Zero {
                         .map(|secret| format!("\"{}\"", &secret))
                         .collect::<Vec<String>>()
                         .join(", "),
+                    &self.caller_name.unwrap_or_default(),
                 )
         })) {
             value
@@ -109,6 +113,7 @@ impl Zero {
 
         Ok(Self {
             api_url: String::from("https://core.tryzero.com/v1/graphql"),
+            caller_name: arguments.caller_name,
             pick: arguments.pick.unwrap_or(vec![]),
             token: arguments.token,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl Zero {
             "query":
                 format!(
                     "query {{
-                        secrets(zeroToken: \"{}\", pick: [{}], callerName: \"{}\") {{
+                        secrets(zeroToken: \"{}\", pick: [{}]{}) {{
                             name
                             fields {{
                                 name value
@@ -59,7 +59,13 @@ impl Zero {
                         .map(|secret| format!("\"{}\"", &secret))
                         .collect::<Vec<String>>()
                         .join(", "),
-                    &self.caller_name.unwrap_or_default(),
+
+                    // REVIEW There should be a better way for string interpolation
+                    if self.caller_name.is_some() {
+                        format!(", callerName: \"{}\"", &self.caller_name.unwrap_or_default())
+                    } else {
+                        "".to_string()
+                    },
                 )
         })) {
             value

--- a/src/tests/mock_and_fetch.rs
+++ b/src/tests/mock_and_fetch.rs
@@ -53,7 +53,7 @@ pub fn mock_and_fetch(
         when.method(httpmock::prelude::POST)
             .path("/v1/graphql")
             .body_contains(&format!(
-                "secrets(zeroToken: \\\"{}\\\", pick: [{}], caller_name: \\\"{}\\\")",
+                "secrets(zeroToken: \\\"{}\\\", pick: [{}], callerName: \\\"{}\\\")",
                 TOKEN, pick_query, "",
             ));
 

--- a/src/tests/mock_and_fetch.rs
+++ b/src/tests/mock_and_fetch.rs
@@ -53,8 +53,8 @@ pub fn mock_and_fetch(
         when.method(httpmock::prelude::POST)
             .path("/v1/graphql")
             .body_contains(&format!(
-                "secrets(zeroToken: \\\"{}\\\", pick: [{}])",
-                TOKEN, pick_query
+                "secrets(zeroToken: \\\"{}\\\", pick: [{}], caller_name: \\\"{}\\\")",
+                TOKEN, pick_query, "",
             ));
 
         then.status(200)
@@ -66,6 +66,7 @@ pub fn mock_and_fetch(
     let secrets = super::super::Zero::new(super::super::Arguments {
         pick,
         token: String::from(TOKEN),
+        caller_name: None,
     })
     .unwrap()
     .set_api_url(arguments.server.url("/v1/graphql"))

--- a/src/tests/mock_and_fetch.rs
+++ b/src/tests/mock_and_fetch.rs
@@ -14,7 +14,7 @@ pub fn mock_and_fetch(
     options: Option<Options>,
 ) -> Result<std::collections::HashMap<String, std::collections::HashMap<String, String>>, String> {
     const TOKEN: &str = "token";
-    const CALLER_NAME: &str = "this-is-a-caller";
+    const CALLER_NAME: &str = "cicd";
 
     let caller_name_query = if !options.is_none() && options.as_ref().unwrap().is_caller_name_empty {
         String::from("")

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -24,8 +24,9 @@ pub fn it_sends_empty_pick_if_it_wasnt_provided() {
     let server = httpmock::prelude::MockServer::start();
 
     let secrets = mock_and_fetch::mock_and_fetch(
-        mock_and_fetch::Arguments { server },
+        mock_and_fetch::Arguments { server: &server },
         Some(mock_and_fetch::Options {
+            is_caller_name_empty: true,
             is_pick_empty: true,
             is_response_failed: false,
         }),
@@ -41,7 +42,7 @@ pub fn it_sends_empty_pick_if_it_wasnt_provided() {
 pub fn it_sends_provided_pick() {
     let server = httpmock::prelude::MockServer::start();
 
-    let secrets = mock_and_fetch::mock_and_fetch(mock_and_fetch::Arguments { server }, None);
+    let secrets = mock_and_fetch::mock_and_fetch(mock_and_fetch::Arguments { server: &server }, None);
 
     assert!(secrets.is_ok());
 }
@@ -51,12 +52,40 @@ pub fn it_returns_err_in_case_of_graphql_api_error() {
     let server = httpmock::prelude::MockServer::start();
 
     let secrets = mock_and_fetch::mock_and_fetch(
-        mock_and_fetch::Arguments { server },
+        mock_and_fetch::Arguments { server: &server },
         Some(mock_and_fetch::Options {
+            is_caller_name_empty: true,
             is_pick_empty: true,
             is_response_failed: true,
         }),
     );
 
     assert!(secrets.is_err());
+}
+
+#[test]
+pub fn it_sends_caller_name_if_provided() {
+    let server = httpmock::prelude::MockServer::start();
+
+    let secrets = mock_and_fetch::mock_and_fetch(
+        mock_and_fetch::Arguments { server: &server },
+        Some(mock_and_fetch::Options {
+            is_pick_empty: true,
+            is_caller_name_empty: true,
+            is_response_failed: false,
+        }),
+    );
+
+    assert!(secrets.is_ok());
+
+    let secrets = mock_and_fetch::mock_and_fetch(
+        mock_and_fetch::Arguments { server: &server },
+        Some(mock_and_fetch::Options {
+            is_pick_empty: true,
+            is_caller_name_empty: false,
+            is_response_failed: false,
+        }),
+    );
+
+    assert!(secrets.is_ok());
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -5,6 +5,7 @@ pub fn it_requires_token_to_be_non_empty() {
     if let Err(_) = super::Zero::new(super::Arguments {
         pick: Some(vec![]),
         token: String::from("token"),
+        caller_name: None,
     }) {
         panic!("Instantion with a valid token string failed")
     }
@@ -12,6 +13,7 @@ pub fn it_requires_token_to_be_non_empty() {
     if let Ok(_) = super::Zero::new(super::Arguments {
         pick: Some(vec![]),
         token: String::from(""),
+        caller_name: None,
     }) {
         panic!("No error thrown during instantiation with empty token string")
     }


### PR DESCRIPTION
Implements `caller_name` passing through API:

- update `zero` func calling signature
- update `README.md`
